### PR TITLE
Improve security for current github workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,10 @@ jobs:
 
     steps:
       - name: Clone Repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Check gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1


### PR DESCRIPTION
This PR improves the security of the current github workflow by enabling verification of the gradle wrapper jar used in the project. More information on why we should enable this check can be found on the [gradle-wrapper-validation](https://github.com/marketplace/actions/gradle-wrapper-validation) action page.

I also update the checkout action to v2.