### PR TITLE
Add ui for profile screen

### DIFF
--- a/commons/ui/src/main/res/values/colors.xml
+++ b/commons/ui/src/main/res/values/colors.xml
@@ -6,7 +6,7 @@
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
+
 
     <color name="colorPrimary">#0d92b1</color>
     <color name="colorPrimaryVariant">#006481</color>
@@ -15,4 +15,7 @@
     <color name="colorOnBackground">#0d92b1</color>
     <color name="colorOnSurface">#0d92b1</color>
     <color name="landing_background">#ecfdf5</color>
+    <color name="faded_gray">#c1c1c1</color>
+    <color name="dark_gray">#727272</color>
+    <color name="white">#ffffffff</color>
 </resources>

--- a/commons/ui/src/main/res/values/dimens.xml
+++ b/commons/ui/src/main/res/values/dimens.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="space_1dp">1dp</dimen>
+    <dimen name="space_4dp">4dp</dimen>
     <dimen name="space_8dp">8dp</dimen>
     <dimen name="space_12dp">12dp</dimen>
     <dimen name="space_16dp">16dp</dimen>
     <dimen name="space_24dp">24dp</dimen>
     <dimen name="space_32dp">32dp</dimen>
+
+    <dimen name="min_tab_height">48dp</dimen>
+    <dimen name="min_setting_row_height">60dp</dimen>
+    <dimen name="profile_photo_size">128dp</dimen>
+    <dimen name="lesson_photo_size">72dp</dimen>
+    <dimen name="border_1dp">1dp</dimen>
+    <dimen name="corner_4dp">4dp</dimen>
 </resources>

--- a/features/profile/build.gradle.kts
+++ b/features/profile/build.gradle.kts
@@ -9,3 +9,7 @@ plugins {
 android {
     addProductFlavours(this)
 }
+
+dependencies {
+    implementation(project(BuildModules.Commons.UI))
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ExperienceLevelText.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ExperienceLevelText.kt
@@ -1,0 +1,18 @@
+package com.teacherworkout.features.profile
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+
+@Composable
+fun ExperienceLevelText(level: Int) {
+    Text(
+        text = stringResource(id = R.string.experience_level, level.toString()),
+        letterSpacing = MaterialTheme.typography.h4.letterSpacing,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colors.primary,
+        fontSize = MaterialTheme.typography.h4.fontSize
+    )
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileImage.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileImage.kt
@@ -1,0 +1,30 @@
+package com.teacherworkout.features.profile
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+
+@Composable
+fun ProfileImage(modifier: Modifier = Modifier, @DrawableRes imageId: Int = R.drawable.ic_profile_default) {
+    val fadedGray = colorResource(id = R.color.faded_gray)
+    val profileSize = dimensionResource(id = R.dimen.profile_photo_size)
+    Image(
+        painter = painterResource(id = imageId),
+        contentDescription = stringResource(id = R.string.cd_profile_photo),
+        modifier = modifier
+            .width(profileSize)
+            .height(profileSize)
+            .clip(RoundedCornerShape(profileSize / 2))
+            .background(fadedGray)
+    )
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileScreen.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileScreen.kt
@@ -1,0 +1,48 @@
+package com.teacherworkout.features.profile
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.TabRow
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
+import com.teacherworkout.features.profile.results.ResultsTabContent
+import com.teacherworkout.features.profile.settings.SettingsTabContent
+
+@Composable
+fun ProfileScreen() {
+    var tab by remember { mutableStateOf(0) }
+    val space16dp = dimensionResource(id = R.dimen.space_16dp)
+    val minTabHeight = dimensionResource(id = R.dimen.min_tab_height)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier
+            .padding(top = space16dp)
+            .fillMaxWidth()
+    ) {
+        ProfileImage(imageId = R.drawable.ic_profile_default)
+        Spacer(Modifier.height(space16dp))
+        ExperienceLevelText(level = 1024)
+        Spacer(Modifier.height(space16dp))
+        TabRow(
+            selectedTabIndex = tab,
+            backgroundColor = Color.White,
+            contentColor = MaterialTheme.colors.primary
+        ) {
+            ProfileTab(
+                textId = R.string.tab_label_results, isSelected = tab == 0, onTabSelected = { tab = 0 },
+                modifier = Modifier.heightIn(min = minTabHeight)
+            )
+            ProfileTab(
+                textId = R.string.tab_label_settings, isSelected = tab == 1, onTabSelected = { tab = 1 },
+                modifier = Modifier.heightIn(min = minTabHeight)
+            )
+        }
+        when (tab) {
+            0 -> ResultsTabContent(listOf("Category 1", "Category 2", "Category 3", "Category 4", "Category 5"))
+            1 -> SettingsTabContent()
+            else -> error("Unexpected tab requested: $tab")
+        }
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileTab.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/ProfileTab.kt
@@ -1,0 +1,29 @@
+package com.teacherworkout.features.profile
+
+import androidx.annotation.StringRes
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Tab
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+
+@Composable
+fun ProfileTab(
+    @StringRes textId: Int,
+    isSelected: Boolean,
+    onTabSelected: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val fadedGray = colorResource(id = R.color.dark_gray)
+    Tab(
+        selected = isSelected,
+        onClick = onTabSelected,
+        modifier = modifier,
+        selectedContentColor = if (isSelected) MaterialTheme.colors.primary else fadedGray
+    ) {
+        Text(text = stringResource(id = textId), fontWeight = FontWeight.Bold)
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/LessonProgress.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/LessonProgress.kt
@@ -1,0 +1,41 @@
+package com.teacherworkout.features.profile.results
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import com.teacherworkout.features.profile.R
+
+@Composable
+fun LessonProgress(progress: Float) {
+    val space1dp = dimensionResource(id = R.dimen.space_1dp)
+    val space8dp = dimensionResource(id = R.dimen.space_8dp)
+    val border1dp = dimensionResource(id = R.dimen.border_1dp)
+    val corner4dp = dimensionResource(id = R.dimen.corner_4dp)
+    val white = colorResource(id = R.color.white)
+    Box(modifier = Modifier.height(space8dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .border(width = border1dp, color = MaterialTheme.colors.primary, shape = RoundedCornerShape(corner4dp))
+                .background(white),
+            content = {}
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(fraction = progress)
+                .fillMaxHeight()
+                .padding(all = space1dp)
+                .clip(RoundedCornerShape(corner4dp))
+                .background(MaterialTheme.colors.primary),
+            content = {}
+        )
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/LessonsRow.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/LessonsRow.kt
@@ -1,0 +1,63 @@
+package com.teacherworkout.features.profile.results
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.teacherworkout.features.profile.R
+
+@Composable
+fun LessonRow(
+    lessonCategoryText: String,
+    completedLessons: Int,
+    totalLessons: Int,
+    onSelection: () -> Unit
+) {
+    val space4dp = dimensionResource(id = R.dimen.space_4dp)
+    val space8dp = dimensionResource(id = R.dimen.space_8dp)
+    val space16dp = dimensionResource(id = R.dimen.space_16dp)
+    val lessonPhotoSize = dimensionResource(id = R.dimen.lesson_photo_size)
+    Column(modifier = Modifier.clickable { onSelection() }) {
+        Row(modifier = Modifier.padding(space16dp)) {
+            Image(
+                painter = painterResource(id = R.drawable.default_lesson_picture),
+                contentDescription = stringResource(id = R.string.cd_lesson, lessonCategoryText),
+                modifier = Modifier
+                    .width(lessonPhotoSize)
+                    .height(lessonPhotoSize)
+                    .clip(RoundedCornerShape(space8dp))
+            )
+            Spacer(Modifier.width(space16dp))
+            Column {
+                Text(
+                    text = lessonCategoryText,
+                    fontSize = MaterialTheme.typography.body1.fontSize,
+                    color = MaterialTheme.colors.primary,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(space4dp))
+                Text(
+                    text = stringResource(
+                        id = R.string.lesson_progress,
+                        completedLessons.toString(),
+                        totalLessons.toString()
+                    ),
+                    fontSize = MaterialTheme.typography.body2.fontSize
+                )
+                Spacer(Modifier.height(space4dp))
+                LessonProgress(progress = completedLessons.toFloat() / totalLessons.toFloat())
+            }
+        }
+        Divider(modifier = Modifier.padding(start = space16dp, end = space16dp))
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/ResultsTabContent.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/results/ResultsTabContent.kt
@@ -1,0 +1,26 @@
+package com.teacherworkout.features.profile.results
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.teacherworkout.features.profile.R
+
+@Composable
+fun ResultsTabContent(lessonsCategories: List<String>) {
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        item {
+            LessonRow(lessonCategoryText = stringResource(id = R.string.label_lessons_finished), 16, 210) {
+                /* TODO */
+            }
+        }
+        lessonsCategories.forEachIndexed { index, value ->
+            item {
+                LessonRow(lessonCategoryText = value, if (index == 2) 41 else 26, 42) {
+                    /* TODO */
+                }
+            }
+        }
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/settings/SettingsRow.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/settings/SettingsRow.kt
@@ -1,0 +1,39 @@
+package com.teacherworkout.features.profile.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.style.TextAlign
+import com.teacherworkout.features.profile.R
+
+@Composable
+fun SettingsRow(text: String, onSelection: (String) -> Unit) {
+    val minSettingRowHeight = dimensionResource(id = R.dimen.min_setting_row_height)
+    Column {
+        Box(
+            contentAlignment = Alignment.CenterStart,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = minSettingRowHeight)
+                .clickable { onSelection(text) }
+        ) {
+            Text(
+                text = text,
+                textAlign = TextAlign.Start,
+                modifier = Modifier
+                    .fillMaxWidth(),
+                fontSize = MaterialTheme.typography.subtitle1.fontSize
+            )
+        }
+        Divider()
+    }
+}

--- a/features/profile/src/main/kotlin/com/teacherworkout/features/profile/settings/SettingsTabContent.kt
+++ b/features/profile/src/main/kotlin/com/teacherworkout/features/profile/settings/SettingsTabContent.kt
@@ -1,0 +1,52 @@
+package com.teacherworkout.features.profile.settings
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import com.teacherworkout.features.profile.R
+
+@Composable
+fun SettingsTabContent() {
+    val settingsOptions = stringArrayResource(id = R.array.settings_options)
+    val settingChangePhoto = stringResource(id = R.string.setting_change_photo)
+    val settingChangePassword = stringResource(id = R.string.setting_change_password)
+    val settingNotifications = stringResource(id = R.string.setting_notification)
+    val settingLogout = stringResource(id = R.string.setting_logout)
+    val settingDeleteAccount = stringResource(id = R.string.setting_delete_account)
+    val space16dp = dimensionResource(id = R.dimen.space_16dp)
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(space16dp)
+    ) {
+        settingsOptions.forEach { entry ->
+            item {
+                SettingsRow(text = entry) { settingText ->
+                    when (settingText) {
+                        settingChangePhoto -> {
+                            /* TODO */
+                        }
+                        settingChangePassword -> {
+                            /* TODO */
+                        }
+                        settingNotifications -> {
+                            /* TODO */
+                        }
+                        settingLogout -> {
+                            /* TODO */
+                        }
+                        settingDeleteAccount -> {
+                            /* TODO */
+                        }
+                        else -> error("Unknown setting selected: $settingText")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/features/profile/src/main/res/drawable/default_lesson_picture.xml
+++ b/features/profile/src/main/res/drawable/default_lesson_picture.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorPrimary"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M0,0 H24 V24 H0 Z" />
+</vector>

--- a/features/profile/src/main/res/drawable/ic_profile_default.xml
+++ b/features/profile/src/main/res/drawable/ic_profile_default.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.5,9.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M8.5,9.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM7,14c0.78,2.34 2.72,4 5,4s4.22,-1.66 5,-4L7,14z"/>
+</vector>

--- a/features/profile/src/main/res/values/arrays.xml
+++ b/features/profile/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="settings_options">
+        <item>@string/setting_change_photo</item>
+        <item>@string/setting_change_password</item>
+        <item>@string/setting_notification</item>
+        <item>@string/setting_logout</item>
+        <item>@string/setting_delete_account</item>
+    </string-array>
+</resources>

--- a/features/profile/src/main/res/values/strings.xml
+++ b/features/profile/src/main/res/values/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cd_profile_photo">Your profile photo</string>
+    <string name="experience_level">%1$s XP</string>
+    <string name="tab_label_results">Results</string>
+    <string name="tab_label_settings">Settings</string>
+
+    <string name="label_lessons_finished">Finished lessons</string>
+    <string name="cd_lesson">Image for %1$s lessons</string>
+    <string name="lesson_progress">%1$s/%2$s</string>
+    <string name="setting_change_photo">Change profile photo</string>
+    <string name="setting_change_password">Change password</string>
+    <string name="setting_notification">Notifications</string>
+    <string name="setting_logout">Logout</string>
+    <string name="setting_delete_account">Delete account</string>
+</resources>


### PR DESCRIPTION
This PR implements the profile UI as seen in the Figma design(issue #10 ). I've added the implementation in the profile feature module but I think it should be put inside the home feature module as it is a main component in the bottom navigation present in the home module.

### How has it been tested?

Locally as this UI isn't yet connected to the rest of the application.
