### PR TITLE
Improve account related code

### DIFF
--- a/commons/ui/src/main/kotlin/com/teacherworkout/commons/ui/navigation/AppDestinations.kt
+++ b/commons/ui/src/main/kotlin/com/teacherworkout/commons/ui/navigation/AppDestinations.kt
@@ -47,6 +47,8 @@ object AppDestinations {
         object Authentication : AccountScreen("account-authentication")
 
         object ResetPassword : AccountScreen("account-reset-password")
+
+        object ResetPasswordSucceeded: AccountScreen("account-reset-password-succeeded")
     }
 
     object Home {

--- a/commons/ui/src/main/res/drawable/ic_email.xml
+++ b/commons/ui/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/commons/ui/src/main/res/values/dimens.xml
+++ b/commons/ui/src/main/res/values/dimens.xml
@@ -8,6 +8,7 @@
     <dimen name="space_24dp">24dp</dimen>
     <dimen name="space_32dp">32dp</dimen>
 
+    <dimen name="min_touch_size">48dp</dimen>
     <dimen name="min_tab_height">48dp</dimen>
     <dimen name="min_setting_row_height">60dp</dimen>
     <dimen name="profile_photo_size">128dp</dimen>

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/AccountFeature.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/AccountFeature.kt
@@ -14,6 +14,7 @@ import com.teacherworkout.features.account.onboarding.OnBoardingScreen
 import com.teacherworkout.features.account.register.RegisterScreen
 import com.teacherworkout.features.account.register.RegisterViewModel
 import com.teacherworkout.features.account.reset.ResetPasswordScreen
+import com.teacherworkout.features.account.reset.ResetPasswordSucceededScreen
 import com.teacherworkout.features.account.reset.ResetPasswordViewModel
 import org.koin.androidx.compose.getViewModel
 import org.koin.core.context.loadKoinModules
@@ -33,6 +34,9 @@ fun NavGraphBuilder.accountFeature(navHostController: NavHostController) {
         }
         composable(AppDestinations.Account.ResetPassword.route) {
             ResetPasswordScreenDestination(navHostController)
+        }
+        composable(AppDestinations.Account.ResetPasswordSucceeded.route) {
+            ResetPasswordSucceededScreenDestination(navHostController)
         }
         composable(AppDestinations.Account.Onboarding.route) {
             OnBoardingScreen {
@@ -75,4 +79,9 @@ private fun ResetPasswordScreenDestination(navHostController: NavHostController)
         onEventSent = { event -> viewModel.setEvent(event) },
         navController = navHostController
     )
+}
+
+@Composable
+private fun ResetPasswordSucceededScreenDestination(navHostController: NavHostController) {
+    ResetPasswordSucceededScreen(navHostController)
 }

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/auth/AuthScreen.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/auth/AuthScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -33,6 +35,7 @@ fun AuthScreen(
     val space16dp = dimensionResource(id = R.dimen.space_16dp)
     val space8dp = dimensionResource(id = R.dimen.space_8dp)
     val space24dp = dimensionResource(id = R.dimen.space_24dp)
+    val minTouchSize = dimensionResource(id = R.dimen.min_touch_size)
 
     AccountScreenScaffold(titleId = R.string.auth_title, navController = navController) {
         Column(
@@ -55,7 +58,11 @@ fun AuthScreen(
                 labelTextId = R.string.input_password_placeholder,
             ) { onEventSent(AuthContract.Event.SetPassword(it)) }
             Spacer(modifier = Modifier.height(space8dp))
-            TextButton(onClick = { navController.navigate(AppDestinations.Account.ResetPassword.route) }) {
+            TextButton(
+                onClick = { navController.navigate(AppDestinations.Account.ResetPassword.route) },
+                shape = RoundedCornerShape(50),
+                modifier = Modifier.heightIn(min = minTouchSize)
+            ) {
                 Text(text = stringResource(id = R.string.auth_btn_forgot_password))
             }
             Spacer(modifier = Modifier.height(space16dp))
@@ -75,8 +82,11 @@ fun AuthScreen(
                 }
                 NotInitiated -> {
                     Button(
+                        shape = RoundedCornerShape(50),
                         onClick = { onEventSent(AuthContract.Event.Auth) },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = minTouchSize)
                     ) {
                         Text(text = stringResource(id = R.string.auth_btn_auth))
                     }

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/composables/EmailField.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/composables/EmailField.kt
@@ -4,6 +4,7 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
@@ -13,6 +14,7 @@ import androidx.compose.material.icons.filled.Email
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import com.teacherworkout.features.account.R
 
 @Composable
@@ -40,6 +42,7 @@ fun EmailField(
             label = { Text(text = stringResource(labelTextId)) },
             modifier = Modifier.fillMaxWidth(),
             onValueChange = onValueChanged,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
         )
         if (hasError) {
             ErrorText(errorTextId = errorTextId)

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/composables/PasswordField.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/composables/PasswordField.kt
@@ -4,6 +4,7 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -20,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.teacherworkout.features.account.R
@@ -55,7 +57,9 @@ fun PasswordField(
             },
             isError = hasError,
             modifier = Modifier.fillMaxWidth(),
-            label = { Text(text = stringResource(labelTextId)) })
+            label = { Text(text = stringResource(labelTextId)) },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+        )
         if (hasError) {
             ErrorText(errorTextId = errorTextId)
         }

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/landing/AuthenticationUi.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/landing/AuthenticationUi.kt
@@ -15,7 +15,6 @@ import com.teacherworkout.features.account.R
 
 @Composable
 fun AuthenticationUi(modifier: Modifier = Modifier, onAuthenticationRequest: () -> Unit) {
-    val space16dp = dimensionResource(id =  R.dimen.space_16dp)
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.Center
@@ -29,7 +28,7 @@ fun AuthenticationUi(modifier: Modifier = Modifier, onAuthenticationRequest: () 
         TextButton(
             onClick = onAuthenticationRequest,
             modifier = Modifier.alignByBaseline(),
-            shape = RoundedCornerShape(space16dp)
+            shape = RoundedCornerShape(50)
         ) {
             Text(
                 stringResource(id = R.string.landing_btn_auth),

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/landing/RegistrationButton.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/landing/RegistrationButton.kt
@@ -15,9 +15,8 @@ import com.teacherworkout.features.account.R
 @Composable
 fun RegistrationButton(modifier: Modifier = Modifier, onRegistrationRequest: () -> Unit) {
     val space8dp = dimensionResource(id =  R.dimen.space_8dp)
-    val space32dp = dimensionResource(id =  R.dimen.space_32dp)
     Button(
-        onClick = onRegistrationRequest, modifier = modifier, shape = RoundedCornerShape(space32dp)
+        onClick = onRegistrationRequest, modifier = modifier, shape = RoundedCornerShape(50)
     ) {
         Text(
             stringResource(id = R.string.landing_btn_register),

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/register/RegisterScreen.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/register/RegisterScreen.kt
@@ -2,6 +2,7 @@ package com.teacherworkout.features.account.register
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -31,6 +32,7 @@ fun RegisterScreen(
     val space8dp = dimensionResource(id = R.dimen.space_8dp)
     val space16dp = dimensionResource(id = R.dimen.space_16dp)
     val space24dp = dimensionResource(id = R.dimen.space_24dp)
+    val minTouchSize = dimensionResource(id = R.dimen.min_touch_size)
 
     AccountScreenScaffold(titleId = R.string.register_title, navController = navController) {
         Column(
@@ -107,6 +109,7 @@ fun RegisterScreen(
                     }
                 }
                 NotInitiated -> Button(
+                    shape = RoundedCornerShape(50),
                     enabled = state.isNotStarted,
                     onClick = {
                         if (state.hasAcceptedTos) {
@@ -117,7 +120,9 @@ fun RegisterScreen(
                             }
                         }
                     },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = minTouchSize)
                 ) {
                     Text(text = stringResource(id = R.string.register_btn_complete))
                 }

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/register/RegisterViewModel.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/register/RegisterViewModel.kt
@@ -39,7 +39,7 @@ class RegisterViewModel :
             val passwordStatus = passwordValidator.validate(viewState.value.password)
 
             if (emailStatus.isValid && passwordStatus.isValid) {
-                delay(3000)
+                delay(1000)
                 if (count == 0) {
                     setState {
                         viewState.value.copy(registrationOutcome = Failed)

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordContract.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordContract.kt
@@ -11,16 +11,11 @@ class ResetPasswordContract {
         object ResetPassword : Event()
 
         data class SetEmail(val email: String) : Event()
-
-        data class SetPassword(val password: String) : Event()
     }
 
     data class State(
         val email: String = "",
         val emailStatus: EmailValidationStatus = EmailValidationStatus.Valid,
-        val password: String = "",
-        val passwordStatus: PasswordValidationStatus = PasswordValidationStatus.Valid,
-        val hasAcceptedTos: Boolean = false,
         val resetOutcome: ResetPasswordOutcome = NotInitiated,
     ) : ViewState
 
@@ -29,9 +24,6 @@ class ResetPasswordContract {
 
 val ResetPasswordContract.State.emailHasError
     get() = emailStatus != EmailValidationStatus.Valid
-
-val ResetPasswordContract.State.passwordHasError
-    get() = passwordStatus != PasswordValidationStatus.Valid
 
 val ResetPasswordContract.State.isNotStarted
     get() = this.resetOutcome == NotInitiated

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordScreenSucceededScreen.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordScreenSucceededScreen.kt
@@ -1,0 +1,41 @@
+package com.teacherworkout.features.account.reset
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.teacherworkout.features.account.R
+import com.teacherworkout.features.account.composables.AccountScreenScaffold
+
+@Composable
+fun ResetPasswordSucceededScreen(navHostController: NavHostController) {
+    val space16dp = dimensionResource(id = R.dimen.space_16dp)
+    AccountScreenScaffold(titleId = R.string.reset_password_succeeded_title, navController = navHostController) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = space16dp)
+        ) {
+            Image(
+                colorFilter = ColorFilter.tint(colorResource(id = R.color.colorPrimary)),
+                painter = painterResource(id = R.drawable.ic_email),
+                contentDescription = stringResource(id = R.string.reset_password_cd_email)
+            )
+            Spacer(modifier = Modifier.width(space16dp))
+            Text(text = stringResource(id = R.string.reset_password_success_label))
+        }
+    }
+}

--- a/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordViewModel.kt
+++ b/features/account/src/main/kotlin/com/teacherworkout/features/account/reset/ResetPasswordViewModel.kt
@@ -1,15 +1,10 @@
 package com.teacherworkout.features.account.reset
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teacherworkout.commons.ui.base.BaseViewModel
-import com.teacherworkout.features.account.register.RegisterContract
 import com.teacherworkout.features.account.validators.EmailValidator
-import com.teacherworkout.features.account.validators.PasswordValidator
 import com.teacherworkout.features.account.validators.isValid
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class ResetPasswordViewModel :
@@ -19,18 +14,14 @@ class ResetPasswordViewModel :
             ResetPasswordContract.Effect>() {
 
     private val emailValidator = EmailValidator()
-    private val passwordValidator = PasswordValidator()
     private var count = 0
 
-
-    override fun setInitialState(): ResetPasswordContract.State =
-        ResetPasswordContract.State()
+    override fun setInitialState(): ResetPasswordContract.State = ResetPasswordContract.State()
 
     override fun handleEvents(event: ResetPasswordContract.Event) {
         when (event) {
             is ResetPasswordContract.Event.ResetPassword -> resetAccountPassword()
             is ResetPasswordContract.Event.SetEmail -> setEmail(event.email)
-            is ResetPasswordContract.Event.SetPassword -> setPassword(event.password)
         }
     }
 
@@ -40,9 +31,8 @@ class ResetPasswordViewModel :
         viewModelScope.launch {
             setState { viewState.value.copy(resetOutcome = InProgress) }
             val emailStatus = emailValidator.validate(viewState.value.email)
-            val passwordStatus = passwordValidator.validate(viewState.value.password)
-            if (emailStatus.isValid && passwordStatus.isValid) {
-                delay(3000)
+            if (emailStatus.isValid) {
+                delay(1000)
                 if (count == 0) {
                     setState { viewState.value.copy(resetOutcome = Failed) }
                     count++
@@ -53,7 +43,6 @@ class ResetPasswordViewModel :
                 setState {
                     viewState.value.copy(
                         emailStatus = emailStatus,
-                        passwordStatus = passwordStatus,
                         resetOutcome = NotInitiated
                     )
                 }
@@ -63,13 +52,6 @@ class ResetPasswordViewModel :
 
     private fun setEmail(email: String) {
         val status = emailValidator.validate(email)
-
         setState { viewState.value.copy(email = email, emailStatus = status) }
-    }
-
-    private fun setPassword(password: String) {
-        val status = passwordValidator.validate(password)
-
-        setState { viewState.value.copy(password = password, passwordStatus = status) }
     }
 }

--- a/features/account/src/main/res/values-ro-rRO/strings.xml
+++ b/features/account/src/main/res/values-ro-rRO/strings.xml
@@ -30,13 +30,15 @@
     <string name="auth_loading_label">Logheaza-te în contul tau…</string>
     <string name="auth_btn_auth">Autentifică-te</string>
     <string name="auth_failure_label">E-mail-ul sau parola sunt incorecte.</string>
+    <!-- Reset password screen related strings -->
     <string name="reset_password_title">Resetează-ți parola</string>
-    <string name="reset_password_account_notice_label">Adresa de email</string>
-    <string name="reset_password_password_notice_label">Parola nouă</string>
     <string name="reset_password_btn_complete">Setează noua parolă</string>
     <string name="reset_password_loading_label">Resetează</string>
     <string name="reset_password_failure_label">Nu v-am putut reseta parola. Vă rugăm să încercați din nou!</string>
-    <string name="reset_password_success_label">Un e-mail pentru resetarea parolei a fost trimis la adresa de e-mail introdusă.</string>
+    <string name="reset_password_succeeded_title">Verifică-ți e-mailul</string>
+    <string name="reset_password_cd_email">Iconiță pentru email</string>
+    <string name="reset_password_success_label">Un e-mail pentru resetarea parolei a fost trimis la adresa de e-mail
+        introdusă. După ce veți urma acel link veți putea folosi noua parolă!</string>
 
     <!-- OnBoarding screen related strings -->
     <string name="onboarding_btn_skip">TRECI PESTE</string>

--- a/features/account/src/main/res/values/strings.xml
+++ b/features/account/src/main/res/values/strings.xml
@@ -45,11 +45,11 @@
         try again!</string>
     <!-- Reset password screen related strings -->
     <string name="reset_password_title">Reset the account password</string>
-    <string name="reset_password_account_notice_label">The email of the account</string>
-    <string name="reset_password_password_notice_label">Enter the new password</string>
     <string name="reset_password_btn_complete">Reset Password</string>
     <string name="reset_password_loading_label">Trying to reset your password…</string>
     <string name="reset_password_failure_label">Could not reset your password. Please try again!</string>
+    <string name="reset_password_succeeded_title">Verify your email</string>
+    <string name="reset_password_cd_email">Email icon</string>
     <string name="reset_password_success_label">We\'ve sent a confirmation link to the email you provided. After
         clicking that link you can then sign in using the new password!</string>
 

--- a/features/account/src/test/java/com/teacherworkout/features/account/auth/AuthViewModelTest.kt
+++ b/features/account/src/test/java/com/teacherworkout/features/account/auth/AuthViewModelTest.kt
@@ -1,31 +1,34 @@
 package com.teacherworkout.features.account.auth
 
 import com.google.common.truth.Truth.assertThat
+import com.teacherworkout.features.account.data.AccountTestData.VALID_EMAIL
+import com.teacherworkout.features.account.data.AccountTestData.VALID_PASSWORD
+import org.junit.Before
 import org.junit.Test
 
 class AuthViewModelTest {
-    @Test
-    fun `setInitialState will set the initial state`() {
-        val viewModel = AuthViewModel()
 
+    private lateinit var viewModel: AuthViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = AuthViewModel()
+    }
+
+    @Test
+    fun `initialState is expected state`() {
         assertThat(viewModel.setInitialState()).isEqualTo(AuthContract.State())
     }
 
     @Test
     fun `handleEvents will handle SetEmail`() {
-        val viewModel = AuthViewModel()
-
-        viewModel.handleEvents(AuthContract.Event.SetEmail("ion@code4.ro"))
-
-        assertThat(viewModel.viewState.value.email).isEqualTo("ion@code4.ro")
+        viewModel.handleEvents(AuthContract.Event.SetEmail(VALID_EMAIL))
+        assertThat(viewModel.viewState.value.email).isEqualTo(VALID_EMAIL)
     }
 
     @Test
     fun `handleEvents will handle SetPassword`() {
-        val viewModel = AuthViewModel()
-
-        viewModel.handleEvents(AuthContract.Event.SetPassword("horsestampler"))
-
-        assertThat(viewModel.viewState.value.password).isEqualTo("horsestampler")
+        viewModel.handleEvents(AuthContract.Event.SetPassword(VALID_PASSWORD))
+        assertThat(viewModel.viewState.value.password).isEqualTo(VALID_PASSWORD)
     }
 }

--- a/features/account/src/test/java/com/teacherworkout/features/account/data/AccountTestData.kt
+++ b/features/account/src/test/java/com/teacherworkout/features/account/data/AccountTestData.kt
@@ -1,0 +1,20 @@
+package com.teacherworkout.features.account.data
+
+object AccountTestData {
+
+    const val VALID_EMAIL = "john.doe@johndoe.com"
+
+    const val VALID_PASSWORD = "A1!querty"
+
+    const val EMPTY = ""
+
+    const val INVALID_EMAIL = "john.doe"
+
+    const val INVALID_PASSWORD_NO_UPPERCASE = "qwerty1234!"
+
+    const val INVALID_PASSWORD_NO_LOWERCASE = "QWERTY1234!"
+
+    const val INVALID_PASSWORD_NO_DIGIT = "ABCqwerty!"
+
+    const val INVALID_PASSWORD_NO_SPECIAL_CHAR = "ABCqwerty1234"
+}

--- a/features/account/src/test/java/com/teacherworkout/features/account/register/RegisterViewModelTest.kt
+++ b/features/account/src/test/java/com/teacherworkout/features/account/register/RegisterViewModelTest.kt
@@ -1,0 +1,112 @@
+package com.teacherworkout.features.account.register
+
+import com.google.common.truth.Truth.assertThat
+import com.teacherworkout.features.account.data.AccountTestData.EMPTY
+import com.teacherworkout.features.account.data.AccountTestData.INVALID_EMAIL
+import com.teacherworkout.features.account.data.AccountTestData.INVALID_PASSWORD_NO_DIGIT
+import com.teacherworkout.features.account.data.AccountTestData.INVALID_PASSWORD_NO_LOWERCASE
+import com.teacherworkout.features.account.data.AccountTestData.INVALID_PASSWORD_NO_SPECIAL_CHAR
+import com.teacherworkout.features.account.data.AccountTestData.INVALID_PASSWORD_NO_UPPERCASE
+import com.teacherworkout.features.account.data.AccountTestData.VALID_EMAIL
+import com.teacherworkout.features.account.data.AccountTestData.VALID_PASSWORD
+import com.teacherworkout.features.account.validators.EmailValidationStatus
+import com.teacherworkout.features.account.validators.PasswordValidationStatus
+import org.junit.Before
+import org.junit.Test
+
+class RegisterViewModelTest {
+
+    private lateinit var viewModel: RegisterViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = RegisterViewModel()
+    }
+
+
+    @Test
+    fun `initialState is expected state`() {
+        assertThat(viewModel.setInitialState()).isEqualTo(RegisterContract.State())
+    }
+
+    @Test
+    fun `viewState has expected value with SetEmail(validEmail)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetEmail(VALID_EMAIL))
+        with(viewModel.viewState.value) {
+            assertThat(email).isEqualTo(VALID_EMAIL)
+            assertThat(emailStatus).isEqualTo(EmailValidationStatus.Valid)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetEmail(emptyEmail)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetEmail(EMPTY))
+        with(viewModel.viewState.value) {
+            assertThat(email).isEqualTo(EMPTY)
+            assertThat(emailStatus).isEqualTo(EmailValidationStatus.Invalid)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetEmail(invalidEmail)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetEmail(INVALID_EMAIL))
+        with(viewModel.viewState.value) {
+            assertThat(email).isEqualTo(INVALID_EMAIL)
+            assertThat(emailStatus).isEqualTo(EmailValidationStatus.Invalid)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(validPassword)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(VALID_PASSWORD))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(VALID_PASSWORD)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.Valid)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(tooShortPassword)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(EMPTY))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(EMPTY)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.TooShort)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(noUppercase)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(INVALID_PASSWORD_NO_UPPERCASE))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(INVALID_PASSWORD_NO_UPPERCASE)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.NoUppercase)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(noLowercase)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(INVALID_PASSWORD_NO_LOWERCASE))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(INVALID_PASSWORD_NO_LOWERCASE)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.NoLowercase)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(noDigit)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(INVALID_PASSWORD_NO_DIGIT))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(INVALID_PASSWORD_NO_DIGIT)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.NoDigit)
+        }
+    }
+
+    @Test
+    fun `viewState has expected value with SetPassword(noSpecialChar)`() {
+        viewModel.handleEvents(RegisterContract.Event.SetPassword(INVALID_PASSWORD_NO_SPECIAL_CHAR))
+        with(viewModel.viewState.value) {
+            assertThat(password).isEqualTo(INVALID_PASSWORD_NO_SPECIAL_CHAR)
+            assertThat(passwordStatus).isEqualTo(PasswordValidationStatus.NoSpecialChar)
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the code related to the account feature:

- it implements the reset password UI as in the mockup(figma screens 2.05 and 2.06,  2.7 needs a discussion after the backend is implemented)
- improves the UI(proper rounded buttons) and usability(minimum touch areas for buttons, proper keyboard input types for our fields)
- adds more tests(for RegisterViewModel)